### PR TITLE
Fix build with latest devkitPPC

### DIFF
--- a/SDL/include/SDL_config_wii.h
+++ b/SDL/include/SDL_config_wii.h
@@ -27,18 +27,6 @@
 
 #include <stdarg.h>
 
-/* Types */
-typedef signed char int8_t;
-typedef unsigned char uint8_t;
-typedef signed short int16_t;
-typedef unsigned short uint16_t;
-typedef signed long int32_t;
-typedef unsigned long uint32_t;
-typedef signed long long int64_t;
-typedef unsigned long long uint64_t;
-typedef unsigned int size_t;
-typedef unsigned int uintptr_t;
-
 /* Architecture */
 #define SDL_BYTEORDER		SDL_BIG_ENDIAN
 #define SDL_HAS_64BIT_TYPE	1


### PR DESCRIPTION
Type conflict because of updated newlib. Deleted these type definitions as they are redundant.