### PR TITLE
Bugfix for SDL_GetTicks() with new libogc version.

### DIFF
--- a/SDL/src/timer/wii/SDL_systimer.c
+++ b/SDL/src/timer/wii/SDL_systimer.c
@@ -29,13 +29,16 @@
 
 #include <ogcsys.h>
 
+static Uint64 start;
+
 void SDL_StartTicks(void)
 {
+	start = gettime();
 }
 
 Uint32 SDL_GetTicks (void)
 {
-	const Uint64 ticks	= gettime();
+	const Uint64 ticks	= gettime() - start;
 	const Uint64 ms		= ticks / TB_TIMER_CLOCK;
 	return ms;
 }


### PR DESCRIPTION
SDL_GetTicks() doesn't start with zero if the current libogc version is used. But it should.
The API docs of SDL_GetTicks() says: "Returns an unsigned 32-bit value representing the number of milliseconds since the SDL library initialized."

The problem is that the behaviour of the libogc function gettime() changed in a newer (current) version of libogc (I don't know at which libogc version this happend). The old libogc Version returns a timestamp relative to the starting point wenn the app was started. The current libogc version returns a very high value. Maybe the absolute time (system time)??? but definitely not the time since the app is started. But sdl-wii rely on the old behaviour.
The bugfix is very easy. The bugfix also works for old libogc versions. If SDL_GetTicks() doesn't start at zero the 32bit value is not enough.